### PR TITLE
fix: rotate EIP via EC2 API instead of CFN param toggle

### DIFF
--- a/lambdas/SsnLambdaSnsTopicSubscriber.py
+++ b/lambdas/SsnLambdaSnsTopicSubscriber.py
@@ -15,25 +15,47 @@ import boto3
 print('Loading function')
 
 
-def change_ip(stack):
-    new_param = []
-    for p in stack.parameters:
-        if p['ParameterKey'] == 'EipDomain':
-            p['ParameterValue'] = 'vpc' if p['ParameterValue'] == '' else ''
-            p['UsePreviousValue'] = False
-        else:
-            p.pop('ParameterValue')
-            p['UsePreviousValue'] = True
-        new_param.append(p)
+def change_ip(stack_id):
+    # Rotate the VPN server's public IP by releasing the current EIP and
+    # allocating a fresh one. The previous implementation toggled the
+    # CloudFormation EipDomain parameter between 'vpc' and '' to force EIP
+    # replacement, but since EC2-Classic was retired (Aug 2022) both values
+    # resolve to a VPC EIP — CFN sees a no-op and the IP never rotates.
+    cfn = boto3.client('cloudformation')
+    ec2 = boto3.client('ec2')
 
-    return stack.update(
-        UsePreviousTemplate=True,
-        Parameters=new_param,
-        Capabilities=[
-            'CAPABILITY_IAM',
-            'CAPABILITY_NAMED_IAM'
-        ]
+    resources = cfn.describe_stack_resources(
+        StackName=stack_id,
+        LogicalResourceId='VPNServerInstance',
+    )['StackResources']
+    instance_id = resources[0]['PhysicalResourceId']
+
+    addresses = ec2.describe_addresses(
+        Filters=[{'Name': 'instance-id', 'Values': [instance_id]}],
+    )['Addresses']
+    if not addresses:
+        raise RuntimeError(f'No EIP associated with instance {instance_id}')
+    old = addresses[0]
+
+    if old.get('AssociationId'):
+        ec2.disassociate_address(AssociationId=old['AssociationId'])
+    ec2.release_address(AllocationId=old['AllocationId'])
+
+    new = ec2.allocate_address(Domain='vpc')
+    ec2.associate_address(
+        InstanceId=instance_id,
+        AllocationId=new['AllocationId'],
     )
+
+    result = {
+        'InstanceId': instance_id,
+        'OldPublicIp': old.get('PublicIp'),
+        'OldAllocationId': old['AllocationId'],
+        'NewPublicIp': new['PublicIp'],
+        'NewAllocationId': new['AllocationId'],
+    }
+    print('EIP rotated: ' + json.dumps(result))
+    return result
 
 
 def lambda_handler(event, context):
@@ -41,10 +63,7 @@ def lambda_handler(event, context):
     message = event['Records'][0]['Sns']['Message']
     print('Message body: ' + message)
 
-    cfn = boto3.resource('cloudformation')
-    stack = cfn.Stack(os.getenv('STACK_ID'))
-
     # convert to lower and remove any [_- \t]
     message = message.lower().translate({ord(i): None for i in ['_', '-', ' ', '\t']})
     if message == 'changeip':
-        return change_ip(stack)
+        return change_ip(os.getenv('STACK_ID'))


### PR DESCRIPTION
## Summary
- `SsnLambdaSnsTopicSubscriber.change_ip` used to flip the `EipDomain` CFN parameter between `vpc` and the empty string to force EIP replacement. After EC2-Classic was retired (Aug 2022), both values resolve to a VPC EIP — CFN sees a no-op, the IP never rotates.
- Replace the parameter toggle with direct EC2 API calls: look up the VPN server instance from the stack, disassociate + release the current EIP, allocate a fresh one, associate it back. The Lambda role already has `AdministratorAccess` so no IAM change is needed.

## Verification
End-to-end test with a self-contained CFN deploy in `210049841009`/`us-east-1`:
- Before: `PublicIp=3.225.144.138, AllocationId=eipalloc-0868ab88bf0baa924`
- After:  `PublicIp=32.192.31.66,  AllocationId=eipalloc-01a49b2cc1f267dbd`
- Lambda log shows the rotation via the new code path; instance public IP flipped accordingly; no resource leaks.

## Follow-up (not in this PR)
The CFN template still owns the original `AllocationId` via its `AWS::EC2::EIP` resource. Once rotation runs, that resource drifts (confirmed in the test: the new EIP survived stack deletion as an orphan). A template-level change to either stop managing the EIP via CFN or import-existing on next deploy is required before the next stack update touches that resource.

## Test plan
- [ ] Merge into `develop`, redeploy a node stack
- [ ] Publish `changeip` to the SNS topic
- [ ] Confirm the instance's public IP rotates and the old EIP is released

🤖 Generated with [Claude Code](https://claude.com/claude-code)
