### PR TITLE
feat: add Architecture parameter for ARM64 (Graviton) support

### DIFF
--- a/stack.json
+++ b/stack.json
@@ -175,7 +175,7 @@
       "Properties": {
         "ImageId": {"Fn::If": [
           "IsArm64",
-          {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMI_ARM64"]},
+          {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMIARM64"]},
           {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMI"]}
         ]},
         "InstanceType": {"Ref": "InstanceType"},
@@ -1232,8 +1232,8 @@
       "ap-northeast-1": {
         "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
         "AMI": "ami-03ede6cc926992148",
-        "name_arm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
-        "AMI_ARM64": "ami-09be0d7ea855efaf9",
+        "nameARM64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIARM64": "ami-09be0d7ea855efaf9",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "Asia Pacific (Tokyo)"
       },

--- a/stack.json
+++ b/stack.json
@@ -175,8 +175,8 @@
       "Properties": {
         "ImageId": {"Fn::If": [
           "IsArm64",
-          {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMIARM64"]},
-          {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMI"]}
+          {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMIArm64"]},
+          {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMIAmd64"]}
         ]},
         "InstanceType": {"Ref": "InstanceType"},
         "KeyName": {"Ref": "KeyPairName"},
@@ -1230,106 +1230,106 @@
   "Mappings": {
     "RegionMap": {
       "ap-northeast-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-03ede6cc926992148",
-        "nameARM64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
-        "AMIARM64": "ami-09be0d7ea855efaf9",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-03ede6cc926992148",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-09be0d7ea855efaf9",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "Asia Pacific (Tokyo)"
       },
       "ap-northeast-2": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-01dc121da1bd8cc87",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-01dc121da1bd8cc87",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "Asia Pacific (Seoul)"
       },
       "ap-northeast-3": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-09e1f9a41bc2f8541",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-09e1f9a41bc2f8541",
         "created": "2024-02-23T06:31:45.000Z",
         "location": "Asia Pacific (Osaka)"
       },
       "ap-south-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0ed547d7a23441118",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0ed547d7a23441118",
         "created": "2024-02-23T06:31:47.000Z",
         "location": "Asia Pacific (Mumbai)"
       },
       "ap-southeast-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-03869643c4ee0fd51",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-03869643c4ee0fd51",
         "created": "2024-02-23T06:31:47.000Z",
         "location": "Asia Pacific (Singapore)"
       },
       "ap-southeast-2": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-04583d641c7c2871f",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-04583d641c7c2871f",
         "created": "2024-02-23T06:32:22.000Z",
         "location": "Asia Pacific (Sydney)"
       },
       "ca-central-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-06d0a340faaedb8d3",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-06d0a340faaedb8d3",
         "created": "2024-02-23T06:31:44.000Z",
         "location": "Canada (Central)"
       },
       "eu-central-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0ac502ad8555a7341",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0ac502ad8555a7341",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "Europe (Frankfurt)"
       },
       "eu-north-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0c25aa580e098d764",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0c25aa580e098d764",
         "created": "2024-02-23T06:31:47.000Z",
         "location": "Europe (Stockholm)"
       },
       "eu-west-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0e0db53b7d6e32e58",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0e0db53b7d6e32e58",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "Europe (Ireland)"
       },
       "eu-west-2": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-080ec4e3c19f17d45",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-080ec4e3c19f17d45",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "Europe (London)"
       },
       "eu-west-3": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0f634594a95cadb9a",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0f634594a95cadb9a",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "Europe (Paris)"
       },
       "sa-east-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0df5f057ad37dc9f6",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0df5f057ad37dc9f6",
         "created": "2024-02-23T06:31:47.000Z",
         "location": "South America (Sao Paulo)"
       },
       "us-east-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-014d544cfef21b42d",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-014d544cfef21b42d",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "US East (N. Virginia)"
       },
       "us-east-2": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0da9b6167383dde73",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0da9b6167383dde73",
         "created": "2024-02-23T06:31:45.000Z",
         "location": "US East (Ohio)"
       },
       "us-west-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-082280ab3970ebe51",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-082280ab3970ebe51",
         "created": "2024-02-23T06:31:44.000Z",
         "location": "US West (N. California)"
       },
       "us-west-2": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0dfd45428f2d4af0c",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0dfd45428f2d4af0c",
         "created": "2024-02-23T06:31:45.000Z",
         "location": "US West (Oregon)"
       }

--- a/stack.json
+++ b/stack.json
@@ -173,7 +173,11 @@
     "VPNServerInstance": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
-        "ImageId": {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMI"]},
+        "ImageId": {"Fn::If": [
+          "IsArm64",
+          {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMI_ARM64"]},
+          {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMI"]}
+        ]},
         "InstanceType": {"Ref": "InstanceType"},
         "KeyName": {"Ref": "KeyPairName"},
         "Monitoring": {"Ref": "Monitoring"},
@@ -792,6 +796,9 @@
     }
   },
   "Conditions": {
+    "IsArm64": {
+      "Fn::Equals": [{"Ref": "Architecture"}, "arm64"]
+    },
     "EnableVpcPeerAcceptor": {
       "Fn::Equals": [{"Ref": "EnableVpcPeerAcceptor"}, "1"]
     },
@@ -861,6 +868,12 @@
     }
   },
   "Parameters": {
+    "Architecture": {
+      "Type": "String",
+      "Default": "x86_64",
+      "AllowedValues": ["x86_64", "arm64"],
+      "Description": "CPU architecture for the VPN server instance. Must be compatible with the chosen InstanceType (e.g. 'arm64' for t4g.* / a1.* / m6g.* etc., 'x86_64' for t2/t3/m5/etc.). Default is 'x86_64'."
+    },
     "VpcCidrBlock": {
       "Type": "String",
       "Default": "10.0.0.0/16",
@@ -1219,6 +1232,8 @@
       "ap-northeast-1": {
         "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
         "AMI": "ami-03ede6cc926992148",
+        "name_arm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMI_ARM64": "ami-09be0d7ea855efaf9",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "Asia Pacific (Tokyo)"
       },


### PR DESCRIPTION
## Summary

Add an `Architecture` parameter (default `x86_64`, allowed `[x86_64, arm64]`) so the VPN server instance can launch on Graviton (e.g. `t4g.nano`, `m6g.*`). Backward-compatible — default behavior is unchanged.

## Changes

- `Parameters.Architecture` — new String param, default `x86_64`, allowed `[x86_64, arm64]`.
- `Conditions.IsArm64` — `Fn::Equals` against the new param.
- `Resources.VPNServerInstance.Properties.ImageId` — switched to `Fn::If: [IsArm64, FindInMap …AMIArm64, FindInMap …AMIAmd64]`.
- `Mappings.RegionMap` — RegionMap keys renamed to **symmetric, explicitly-labelled** keys: `name`/`AMI` → `nameAmd64`/`AMIAmd64` (x86_64), and an `nameArm64`/`AMIArm64` entry added for `ap-northeast-1` (`ami-09be0d7ea855efaf9`, Amazon Linux 2 arm64). The symmetric naming avoids an unlabelled x86 default sitting next to a suffixed arm64 key.

## Dependency — must land/run with the ami-utility change

The `xsh aws/cfn/vpn/ami` utility regenerates the **entire** `RegionMap`. The old (x86-only) utility would wipe the arm64 keys (and doesn't know the new `Amd64`/`Arm64` names) on its next run. Companion PR **xsh-lib/aws#5** (`feat/ami-arm64-mapping`) teaches the utility to emit `nameAmd64`/`AMIAmd64` + `nameArm64`/`AMIArm64` natively. **Merge + `xsh upgrade` the utility before regenerating this map again.** Code-wise the two PRs are independent (this one is safe to merge alone); the dependency is operational.

## Backward compatibility

- Default `Architecture=x86_64` → `IsArm64` false → resolves `AMIAmd64` → same AMI selection as the old `AMI` key. Existing stacks updated with this template see only a new unused parameter (no resource diff), provided the RegionMap is regenerated with the Amd64/Arm64-aware utility so the `AMIAmd64` key exists.

## Region coverage (follow-up)

Only `ap-northeast-1` currently carries an `AMIArm64` entry; other regions would fail `FindInMap[AMIArm64]` under `Architecture=arm64`. Once xsh-lib/aws#5 is merged and `@ami -t stack.json` is run, all arm64-publishing regions are populated automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
