### PR TITLE
release: ARM64 (Graviton) Architecture support

### DIFF
--- a/stack.json
+++ b/stack.json
@@ -173,7 +173,11 @@
     "VPNServerInstance": {
       "Type": "AWS::EC2::Instance",
       "Properties": {
-        "ImageId": {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMI"]},
+        "ImageId": {"Fn::If": [
+          "IsArm64",
+          {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMIArm64"]},
+          {"Fn::FindInMap": ["RegionMap", {"Ref": "AWS::Region"}, "AMIAmd64"]}
+        ]},
         "InstanceType": {"Ref": "InstanceType"},
         "KeyName": {"Ref": "KeyPairName"},
         "Monitoring": {"Ref": "Monitoring"},
@@ -792,6 +796,9 @@
     }
   },
   "Conditions": {
+    "IsArm64": {
+      "Fn::Equals": [{"Ref": "Architecture"}, "arm64"]
+    },
     "EnableVpcPeerAcceptor": {
       "Fn::Equals": [{"Ref": "EnableVpcPeerAcceptor"}, "1"]
     },
@@ -861,6 +868,12 @@
     }
   },
   "Parameters": {
+    "Architecture": {
+      "Type": "String",
+      "Default": "x86_64",
+      "AllowedValues": ["x86_64", "arm64"],
+      "Description": "CPU architecture for the VPN server instance. Must be compatible with the chosen InstanceType (e.g. 'arm64' for t4g.* / a1.* / m6g.* etc., 'x86_64' for t2/t3/m5/etc.). Default is 'x86_64'."
+    },
     "VpcCidrBlock": {
       "Type": "String",
       "Default": "10.0.0.0/16",
@@ -1217,104 +1230,106 @@
   "Mappings": {
     "RegionMap": {
       "ap-northeast-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-03ede6cc926992148",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-03ede6cc926992148",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-09be0d7ea855efaf9",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "Asia Pacific (Tokyo)"
       },
       "ap-northeast-2": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-01dc121da1bd8cc87",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-01dc121da1bd8cc87",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "Asia Pacific (Seoul)"
       },
       "ap-northeast-3": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-09e1f9a41bc2f8541",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-09e1f9a41bc2f8541",
         "created": "2024-02-23T06:31:45.000Z",
         "location": "Asia Pacific (Osaka)"
       },
       "ap-south-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0ed547d7a23441118",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0ed547d7a23441118",
         "created": "2024-02-23T06:31:47.000Z",
         "location": "Asia Pacific (Mumbai)"
       },
       "ap-southeast-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-03869643c4ee0fd51",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-03869643c4ee0fd51",
         "created": "2024-02-23T06:31:47.000Z",
         "location": "Asia Pacific (Singapore)"
       },
       "ap-southeast-2": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-04583d641c7c2871f",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-04583d641c7c2871f",
         "created": "2024-02-23T06:32:22.000Z",
         "location": "Asia Pacific (Sydney)"
       },
       "ca-central-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-06d0a340faaedb8d3",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-06d0a340faaedb8d3",
         "created": "2024-02-23T06:31:44.000Z",
         "location": "Canada (Central)"
       },
       "eu-central-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0ac502ad8555a7341",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0ac502ad8555a7341",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "Europe (Frankfurt)"
       },
       "eu-north-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0c25aa580e098d764",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0c25aa580e098d764",
         "created": "2024-02-23T06:31:47.000Z",
         "location": "Europe (Stockholm)"
       },
       "eu-west-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0e0db53b7d6e32e58",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0e0db53b7d6e32e58",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "Europe (Ireland)"
       },
       "eu-west-2": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-080ec4e3c19f17d45",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-080ec4e3c19f17d45",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "Europe (London)"
       },
       "eu-west-3": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0f634594a95cadb9a",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0f634594a95cadb9a",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "Europe (Paris)"
       },
       "sa-east-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0df5f057ad37dc9f6",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0df5f057ad37dc9f6",
         "created": "2024-02-23T06:31:47.000Z",
         "location": "South America (Sao Paulo)"
       },
       "us-east-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-014d544cfef21b42d",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-014d544cfef21b42d",
         "created": "2024-02-23T06:31:46.000Z",
         "location": "US East (N. Virginia)"
       },
       "us-east-2": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0da9b6167383dde73",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0da9b6167383dde73",
         "created": "2024-02-23T06:31:45.000Z",
         "location": "US East (Ohio)"
       },
       "us-west-1": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-082280ab3970ebe51",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-082280ab3970ebe51",
         "created": "2024-02-23T06:31:44.000Z",
         "location": "US West (N. California)"
       },
       "us-west-2": {
-        "name": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMI": "ami-0dfd45428f2d4af0c",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
+        "AMIAmd64": "ami-0dfd45428f2d4af0c",
         "created": "2024-02-23T06:31:45.000Z",
         "location": "US West (Oregon)"
       }

--- a/stack.json
+++ b/stack.json
@@ -1230,107 +1230,139 @@
   "Mappings": {
     "RegionMap": {
       "ap-northeast-1": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-03ede6cc926992148",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-006364fbd0e812d5e",
         "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
         "AMIArm64": "ami-09be0d7ea855efaf9",
-        "created": "2024-02-23T06:31:46.000Z",
+        "created": "2026-05-21T18:12:45.000Z",
         "location": "Asia Pacific (Tokyo)"
       },
       "ap-northeast-2": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-01dc121da1bd8cc87",
-        "created": "2024-02-23T06:31:46.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-0f0ce59d54cc368b3",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-08a19a5bb68af2bf8",
+        "created": "2026-05-21T18:06:05.000Z",
         "location": "Asia Pacific (Seoul)"
       },
       "ap-northeast-3": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-09e1f9a41bc2f8541",
-        "created": "2024-02-23T06:31:45.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-040ac1d7bbe22fd8e",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-06b4108cb2375daf3",
+        "created": "2026-05-21T18:06:19.000Z",
         "location": "Asia Pacific (Osaka)"
       },
       "ap-south-1": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-0ed547d7a23441118",
-        "created": "2024-02-23T06:31:47.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-00c5d5e886a26d124",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-0d9a5630e9538b51f",
+        "created": "2026-05-21T18:06:14.000Z",
         "location": "Asia Pacific (Mumbai)"
       },
       "ap-southeast-1": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-03869643c4ee0fd51",
-        "created": "2024-02-23T06:31:47.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-0e8bf7e1d1f339c74",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-05cf69f80c308c1f8",
+        "created": "2026-05-21T18:06:18.000Z",
         "location": "Asia Pacific (Singapore)"
       },
       "ap-southeast-2": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-04583d641c7c2871f",
-        "created": "2024-02-23T06:32:22.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-0c4ca191c5ba10793",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-0dce9d90dde833bac",
+        "created": "2026-05-21T18:06:17.000Z",
         "location": "Asia Pacific (Sydney)"
       },
       "ca-central-1": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-06d0a340faaedb8d3",
-        "created": "2024-02-23T06:31:44.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-0000d5ca154ee91d4",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-053517da2230b7930",
+        "created": "2026-05-21T18:12:43.000Z",
         "location": "Canada (Central)"
       },
       "eu-central-1": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-0ac502ad8555a7341",
-        "created": "2024-02-23T06:31:46.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-0af964531014e9a60",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-01ae2826e5a255590",
+        "created": "2026-05-21T18:12:55.000Z",
         "location": "Europe (Frankfurt)"
       },
       "eu-north-1": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-0c25aa580e098d764",
-        "created": "2024-02-23T06:31:47.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-0d25d4b80a73a8948",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-0b32a3aa8fac8994f",
+        "created": "2026-05-21T18:06:19.000Z",
         "location": "Europe (Stockholm)"
       },
       "eu-west-1": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-0e0db53b7d6e32e58",
-        "created": "2024-02-23T06:31:46.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-0e59c64f4e013cb5f",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-04c19fc5e06cfc88e",
+        "created": "2026-05-21T18:12:47.000Z",
         "location": "Europe (Ireland)"
       },
       "eu-west-2": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-080ec4e3c19f17d45",
-        "created": "2024-02-23T06:31:46.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-0ec7d503f466ab809",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-019fccdbc86099c98",
+        "created": "2026-05-21T18:12:49.000Z",
         "location": "Europe (London)"
       },
       "eu-west-3": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-0f634594a95cadb9a",
-        "created": "2024-02-23T06:31:46.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-06cf836a152a19276",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-05ba889900ecb6b48",
+        "created": "2026-05-21T18:06:18.000Z",
         "location": "Europe (Paris)"
       },
       "sa-east-1": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-0df5f057ad37dc9f6",
-        "created": "2024-02-23T06:31:47.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-0e8494bdfecb07069",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-011ace3574ac85ef7",
+        "created": "2026-05-21T18:06:16.000Z",
         "location": "South America (Sao Paulo)"
       },
       "us-east-1": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-014d544cfef21b42d",
-        "created": "2024-02-23T06:31:46.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-046b36f55e189564a",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-0537561b54bdeb5bc",
+        "created": "2026-05-21T18:12:49.000Z",
         "location": "US East (N. Virginia)"
       },
       "us-east-2": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-0da9b6167383dde73",
-        "created": "2024-02-23T06:31:45.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-0ae3c5abab3d5cb90",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-0a71fc9a8ab5be978",
+        "created": "2026-05-21T18:12:43.000Z",
         "location": "US East (Ohio)"
       },
       "us-west-1": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-082280ab3970ebe51",
-        "created": "2024-02-23T06:31:44.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-0679b96f0452f05e1",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-03be23223285bb7aa",
+        "created": "2026-05-21T18:06:12.000Z",
         "location": "US West (N. California)"
       },
       "us-west-2": {
-        "nameAmd64": "amzn2-ami-hvm-2.0.20240223.0-x86_64-gp2",
-        "AMIAmd64": "ami-0dfd45428f2d4af0c",
-        "created": "2024-02-23T06:31:45.000Z",
+        "nameAmd64": "amzn2-ami-hvm-2.0.20260526.0-x86_64-gp2",
+        "AMIAmd64": "ami-08812a845130824aa",
+        "nameArm64": "amzn2-ami-hvm-2.0.20260526.0-arm64-gp2",
+        "AMIArm64": "ami-0730d412cb3cb28cb",
+        "created": "2026-05-21T18:00:03.000Z",
         "location": "US West (Oregon)"
       }
     }


### PR DESCRIPTION
Ships the ARM64/Graviton support to master.

- **#10**: `Architecture` parameter (x86_64|arm64) switching `VPNServerInstance.ImageId` between `AMIAmd64`/`AMIArm64`; symmetric RegionMap key naming.
- **#11**: regenerated RegionMap with the arm64-aware `xsh aws/cfn/vpn/ami` (xsh-lib/aws 0.3.0) — all 17 regions now carry both architectures; amd64 AMIs re-leveled to current Amazon Linux 2.

Pairs with xsh-lib/aws 0.3.0 (the generator that keeps the map arm64-aware across refreshes).
