### PR TITLE
ci: add cfn-lint and Lambda ruff validation

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -1,0 +1,29 @@
+name: ci-validate
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  cfn-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cfn-lint
+        run: pip install cfn-lint
+      - name: Lint CloudFormation template
+        run: cfn-lint stack.json --ignore-checks W
+
+  lambda-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install ruff
+        run: pip install ruff
+      - name: Lint Lambda functions
+        run: ruff check lambdas/*.py --ignore E501

--- a/lambdas/LambdaSnsTopicSubscriber.py
+++ b/lambdas/LambdaSnsTopicSubscriber.py
@@ -7,7 +7,8 @@ in shadowsocks-manager.
 
 import json
 import os
-import botocore, boto3
+import botocore
+import boto3
 from abc import ABC, abstractmethod
 
 print('Loading function')


### PR DESCRIPTION
Add CI workflow that runs cfn-lint on stack.json and ruff on Lambda Python files. Required before enabling branch protection.