### PR TITLE
security: scope SNS topic policies + least-privilege the SSN subscriber Lambda

### DIFF
--- a/stack.json
+++ b/stack.json
@@ -583,7 +583,7 @@
           "Statement": [
             {
               "Effect": "Allow",
-              "Principal": {"AWS": "*"},
+              "Principal": {"Service": "config.amazonaws.com"},
               "Action": "sns:Publish",
               "Resource": {"Ref": "SnsTopicForConfig"}
             }
@@ -638,8 +638,33 @@
           ]
         },
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          "arn:aws:iam::aws:policy/AdministratorAccess"
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Policies": [
+          {
+            "PolicyName": "ssn-eip-rotate",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "ec2:DescribeAddresses",
+                    "ec2:AllocateAddress",
+                    "ec2:AssociateAddress",
+                    "ec2:DisassociateAddress",
+                    "ec2:ReleaseAddress"
+                  ],
+                  "Resource": "*"
+                },
+                {
+                  "Effect": "Allow",
+                  "Action": "cloudformation:DescribeStackResources",
+                  "Resource": {"Ref": "AWS::StackId"}
+                }
+              ]
+            }
+          }
         ],
         "Path": "/"
       }
@@ -696,7 +721,7 @@
           "Statement": [
             {
               "Effect": "Allow",
-              "Principal": {"AWS": "*"},
+              "Principal": {"AWS": {"Ref": "AWS::AccountId"}},
               "Action": "sns:Publish",
               "Resource": {"Ref": "SnsTopicForSsn"}
             }


### PR DESCRIPTION
## What

Closes both `Principal: {"AWS": "*"}` SNS topic policies and replaces the SSN subscriber Lambda's `AdministratorAccess` with a least-privilege inline policy. All in `stack.json`. Targets **Pattern 2 (wildcard cross-account trust)** and **Pattern 3 (over-broad IAM)** on the SNS-driven automation.

### 1. `SnsTopicPolicyForSsn`: `*` → node's own account
This is the IP-rotation channel behind the recent incident. `*` let **any AWS account** publish `changeip` to the topic, forcing an EIP rotation.

The manager publishes rotation commands using each node's **own** `sns_publisher` IAM key (stored per-node as `sns_access_key`/`sns_secret_key`; see `shadowsocks-manager` `models.py` `change_ip()` building the SNS client from those keys). The publisher is therefore **same-account** as the topic, so scoping `Principal` to `{"Ref": "AWS::AccountId"}` is correct and — unlike scoping to `SSMAccountId` — has no dependency on a param that may be unset on a node deploy.

### 2. `SnsTopicPolicyForConfig`: `*` → AWS Config service principal
The consumer Lambda (`LambdaSnsTopicSubscriber`) parses these messages as Config events and **mutates shadowsocks-manager** (NameServer/Domain/Record/Node/SSManager) via the SSM API Lambda — so `*` was a privileged injection path, not just noise.

Fixed to `{"Service": "config.amazonaws.com"}` (matches how `aws-cfn-config-provider` and AWS Config's `DeliveryChannel` actually publish). **No `aws:SourceAccount` lock here on purpose:** the live confs run `EnableConfigProvider=1` / `EnableConfigConsumer=0` on nodes, i.e. Config delivery is **cross-account** (node provider accounts → a central consumer topic). An own-account `aws:SourceAccount` would break delivery. Scoping `aws:SourceAccount` to the provider-account allow-list is deferred to the **P2 config-provider** work where those account IDs are managed (tracked separately).

### 3. `SsnLambdaSnsTopicSubscriberExecutionRole`: drop `AdministratorAccess`
Replaced with an inline policy containing exactly what the Lambda calls (verified from `lambdas/SsnLambdaSnsTopicSubscriber.py`):
- `ec2:DescribeAddresses`, `AllocateAddress`, `AssociateAddress`, `DisassociateAddress`, `ReleaseAddress` (`Resource: "*"` — these EIP actions have no resource-level support)
- `cloudformation:DescribeStackResources` scoped to `{"Ref": "AWS::StackId"}`

`AWSLambdaBasicExecutionRole` retained for CloudWatch Logs.

## Validation
- `cfn-lint stack.json --ignore-checks W` → pass (matches the `ci-validate.yml` gate); no new warnings on the inline policy.

## Notes
- Branch model: `develop` → `master` (this PR targets `develop`).
- Code/PR only — no live AWS resources touched, no rotation triggered.

Part of the VPN-chain security-patching effort (P1).
