### PR TITLE
security: parameterize hub admin SG (22/80/443) via AdminAllowedCidr

### DIFF
--- a/stack.json
+++ b/stack.json
@@ -71,7 +71,7 @@
             "IpProtocol": "tcp",
             "FromPort": "22",
             "ToPort": "22",
-            "CidrIp": "0.0.0.0/0"
+            "CidrIp": {"Ref": "AdminAllowedCidr"}
           }
         ],
         "Tags": [
@@ -148,7 +148,7 @@
         "IpProtocol": "tcp",
         "FromPort": 80,
         "ToPort": 80,
-        "CidrIp": "0.0.0.0/0",
+        "CidrIp": {"Ref": "AdminAllowedCidr"},
         "GroupId": {"Fn::GetAtt": ["VPNServerSG", "GroupId"]}
       }
     },
@@ -159,7 +159,7 @@
         "IpProtocol": "tcp",
         "FromPort": 443,
         "ToPort": 443,
-        "CidrIp": "0.0.0.0/0",
+        "CidrIp": {"Ref": "AdminAllowedCidr"},
         "GroupId": {"Fn::GetAtt": ["VPNServerSG", "GroupId"]}
       }
     },
@@ -887,6 +887,15 @@
       "Type": "String",
       "Default": "10.0.0.0/16",
       "Description": "Enter CIDR Block for VPC. Default is '10.30.0.0/16' (65536 IPs).",
+      "MinLength": "9",
+      "MaxLength": "18",
+      "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+      "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x."
+    },
+    "AdminAllowedCidr": {
+      "Type": "String",
+      "Default": "0.0.0.0/0",
+      "Description": "CIDR allowed to reach the administrative surfaces: SSH (22), the shadowsocks-manager web UI (80) and TLS UI (443). Defaults to 0.0.0.0/0 for backward compatibility, but SET THIS to your admin/bastion CIDR (e.g. 203.0.113.4/32). Does NOT affect the public VPN service ports (Shadowsocks, L2TP) which must stay open to clients.",
       "MinLength": "9",
       "MaxLength": "18",
       "AllowedPattern": "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",


### PR DESCRIPTION
## What

Parameterizes the hub's **administrative** ingress so it isn't world-open. Targets **Pattern 5** (weak default exposure).

### Before
- `VPNServerSG` SSH **22** → `0.0.0.0/0`
- `SSMWebIngress` **80** (shadowsocks-manager web UI) → `0.0.0.0/0`
- `SSMTlsIngress` **443** (TLS UI) → `0.0.0.0/0`

### After
- New `AdminAllowedCidr` parameter; the three admin rules point at it.
- The **public VPN service ports stay `0.0.0.0/0`** (clients connect from anywhere): Shadowsocks `SSPortBegin..SSPortEnd` TCP/UDP and L2TP `500`/`4500`. `SSManagerPort` keeps its existing peer-CIDR scope.

### Default
`AdminAllowedCidr` defaults to `0.0.0.0/0` to avoid changing behaviour — and risking **admin lockout** — on existing live deploys. **Operators should set it** to their admin/bastion CIDR (e.g. `203.0.113.4/32`) in the deploy conf (`vpn.aiview.com` `OPTIONS`). Moving SSH to **SSM Session Manager** is the better long-term fix (tracked under P3).

## Validation
- `python3 -m json.tool` → valid JSON
- `cfn-lint stack.json --ignore-checks W` → pass (CI gate)
- Confirmed only 22/80/443 changed; the 4 service-port `0.0.0.0/0` rules are untouched.

## Notes
- Branch model: `feature` → `develop` (this PR) → `master`.
- Code/PR only — no live AWS resources touched.

Part of the VPN-chain security-patching effort (P1).
