### PR TITLE
security: wire VpcPeerRequesterAccountIds through to the peer-acceptor stack

### DIFF
--- a/stack.json
+++ b/stack.json
@@ -19,7 +19,8 @@
       "Properties": {
         "TemplateURL": {"Ref": "VpcPeerAcceptorStackTemplateURL"},
         "Parameters": {
-          "RouteTableId": {"Fn::GetAtt": ["VpcStack", "Outputs.PublicRouteTable"]}
+          "RouteTableId": {"Fn::GetAtt": ["VpcStack", "Outputs.PublicRouteTable"]},
+          "PeerRequesterAccountIds": {"Ref": "VpcPeerRequesterAccountIds"}
         },
         "TimeoutInMinutes": "5"
       }
@@ -902,6 +903,11 @@
       "Type": "String",
       "Default": "",
       "Description": "VPC peer acceptor stack template URL, must be an AWS S3 URL."
+    },
+    "VpcPeerRequesterAccountIds": {
+      "Type": "String",
+      "Default": "",
+      "Description": "Used with EnableVpcPeerAcceptor=1. Comma-separated 12-digit AWS account IDs of the node (requester) accounts allowed to assume the peer role and send to the route queue. Passed to the acceptor stack's PeerRequesterAccountIds. The acceptor template requires it (no default there), so leaving this empty fails the acceptor deploy closed instead of trusting every AWS account."
     },
     "EnableVpcPeerRequester": {
       "Type": "String",


### PR DESCRIPTION
## What

Completes the cross-account trust scoping started in [aws-cfn-vpc-peer-acceptor#2](https://github.com/alexzhangs/aws-cfn-vpc-peer-acceptor/pull/2).

That PR made the acceptor template's `PeerRequesterAccountIds` **required** (no default → fail-closed). The hub deployment passed only `RouteTableId` to the nested `VpcPeerAcceptorStack`, so without this change the hub would fail to deploy the acceptor.

- New `VpcPeerRequesterAccountIds` parameter (comma-separated node/requester account IDs), passed through to the acceptor's `PeerRequesterAccountIds`.
- Empty default → the acceptor's required list param receives an empty value → **fails closed** rather than trusting every AWS account.

## ⚠️ Merge order
Merge **aws-cfn-vpc-peer-acceptor#2 first**, then this. (And the released acceptor template URL the hub points at must include #2.)

## Validation
- valid JSON; `cfn-lint stack.json --ignore-checks W` passes.

## Notes
- Branch model: `feature` → `develop` (this PR) → `master`. Independent of the other open aws-cfn-vpn PRs (#17, #18) — different sections, no overlap.

Part of the VPN-chain security-patching effort (P1).
